### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = (content, options = {}) => {
 
         // tests
         isRowHeading = (str) => /^_.+_$/.test(str),
-        strToRowHeading = (str) => trim(str.substr(1, str.length - 2)),
+        strToRowHeading = (str) => trim(str.slice(1, -1)),
 
         // filter table cell
         filterTableCellAttributes = ({


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.